### PR TITLE
Made logging more accurate

### DIFF
--- a/src/pydictionaria/formats/sfm.py
+++ b/src/pydictionaria/formats/sfm.py
@@ -245,7 +245,8 @@ class Dictionary(base.Dictionary):
                 spec['example_columns'],
                 spec['entry_refs'],
                 spec['sense_refs'],
-                spec['example_refs'])
+                spec['example_refs'],
+                log)
 
             if props.get('labels'):
                 sfm2cldf.attach_column_titles(

--- a/src/pydictionaria/formats/sfm.py
+++ b/src/pydictionaria/formats/sfm.py
@@ -162,8 +162,7 @@ class Dictionary(base.Dictionary):
                 marker_list = ', '.join(sorted(all_markers))
                 log.warning('unexpected markers: %s', marker_list)
 
-            # TODO Get rid of unexpected_markers
-            example_index, _ = sfm2cldf.prepare_examples(
+            example_index = sfm2cldf.prepare_examples(
                 spec['example_id'],
                 spec['example_markers'],
                 examples)

--- a/src/pydictionaria/formats/sfm.py
+++ b/src/pydictionaria/formats/sfm.py
@@ -160,7 +160,7 @@ class Dictionary(base.Dictionary):
             all_markers -= set(EXAMPLE_MARKER_MAP.values())
             if all_markers:
                 marker_list = ', '.join(sorted(all_markers))
-                log.warning('unexpected markers: %s', marker_list)
+                log.warning('No CLDF column defined for markers: %s', marker_list)
 
             example_index = sfm2cldf.prepare_examples(
                 spec['example_id'],

--- a/src/pydictionaria/formats/sfm_lib.py
+++ b/src/pydictionaria/formats/sfm_lib.py
@@ -309,28 +309,30 @@ class Rearrange(object):
         move_marker(entry, 'xr', 'xe')
 
 
+EXAMPLE_MARKER_MAP = {
+    'rf': 'rf',
+    'xv': 'tx',
+    'xvm': 'mb',
+    'xeg': 'gl',
+    'xo': 'ot',
+    'xn': 'ot',
+    'xr': 'ota',
+    'xe': 'ft',
+    'sfx': 'sf',
+}
+
+EXAMPLE_START_MARKERS = {'lemma', 'ref', 'rf', 'tx'}
+
+EXAMPLE_END_MARKERS = {'ft'}
+
+
 class ExampleExtractionStateMachine:
-
-    marker_map = {
-        'rf': 'rf',
-        'xv': 'tx',
-        'xvm': 'mb',
-        'xeg': 'gl',
-        'xo': 'ot',
-        'xn': 'ot',
-        'xr': 'ota',
-        'xe': 'ft',
-        'sfx': 'sf',
-    }
-
-    start_markers = {'lemma', 'ref', 'rf', 'tx'}
-    end_markers = {'ft'}
 
     def __init__(self, example_markers, id_generator, log, entry_cls=Entry):
         self.entry = entry_cls()
         self.id_gen = id_generator
         self.log = log
-        self.example_markers = set(self.marker_map)
+        self.example_markers = set(EXAMPLE_MARKER_MAP)
         self.example_markers.update(example_markers)
         self.example = Example()
         self._entry_buffer = []
@@ -341,21 +343,21 @@ class ExampleExtractionStateMachine:
             self.log_error('missing xe')
             self.drop_example()
         self.example.append((marker, content))
-        if marker in self.end_markers:
+        if marker in EXAMPLE_END_MARKERS:
             self._state = self._end
-        elif marker not in self.start_markers:
+        elif marker not in EXAMPLE_START_MARKERS:
             self._state = self._middle
 
     def _middle(self, marker, content):
-        if marker != 'tx' and marker in self.start_markers:
+        if marker != 'tx' and marker in EXAMPLE_START_MARKERS:
             self.finish_example()
             self._state = self._beginning
         self.example.append((marker, content))
-        if marker in self.end_markers:
+        if marker in EXAMPLE_END_MARKERS:
             self._state = self._end
 
     def _end(self, marker, content):
-        if marker in self.start_markers:
+        if marker in EXAMPLE_START_MARKERS:
             self.finish_example()
             self.example.append((marker, content))
 
@@ -370,7 +372,7 @@ class ExampleExtractionStateMachine:
 
     def process_marker(self, marker, content):
         if marker in self.example_markers:
-            self._state(self.marker_map.get(marker, marker), content)
+            self._state(EXAMPLE_MARKER_MAP.get(marker, marker), content)
         elif self.example:
             # Hold off on adding entry markers until the example is done -- to
             # make sure the \xref marker ends up in the right place.

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -184,22 +184,20 @@ class IDGenerator(object):
 
 
 def prepare_examples(example_id, example_markers, database):
-    unexpected_markers = set()
     id_gen = IDGenerator('XV')
     example_index = OrderedDict()
-    for markers in database:
-        extracted_markers, rest = split_by_pred(
-            lambda pair: pair[0] in example_markers,
-            markers)
-        unexpected_markers.update(tag for tag, _ in rest)
 
-        new_example = sfm.Entry(extracted_markers)
+    for old_example in database:
+        new_example = sfm.Entry(
+            (marker, content)
+            for marker, content in old_example
+            if marker in example_markers)
         new_example.id = id_gen.next_id()
         new_example.sense_ids = []
         new_example.media_ids = []
-        example_index[markers.id] = new_example
+        example_index[old_example.id] = new_example
 
-    return example_index, unexpected_markers
+    return example_index
 
 
 class EntryExtractor(object):


### PR DESCRIPTION
 * Show error message, when encountering invalid CLDF column names
 * Determine more accurately, which SFM markers don't map to anything in CLDF
 * More descriptive warning (a.k.a. "`\dt` is not unexpected – we just don't care about it")