### PR TITLE
Split cross-reference processing from link processing

### DIFF
--- a/src/pydictionaria/formats/sfm.py
+++ b/src/pydictionaria/formats/sfm.py
@@ -273,9 +273,9 @@ class Dictionary(base.Dictionary):
                 spec['entry_columns'],
                 spec['sense_columns'],
                 spec['example_columns'],
-                spec['entry_refs'],
-                spec['sense_refs'],
-                spec['example_refs'],
+                spec['entry_sources'],
+                spec['sense_sources'],
+                spec['example_sources'],
                 log)
 
             if props.get('labels'):
@@ -289,13 +289,13 @@ class Dictionary(base.Dictionary):
             sfm2cldf.add_gloss_columns(dataset, glosses)
 
             entry_rows = [
-                sfm2cldf.sfm_entry_to_cldf_row('EntryTable', spec['entry_map'], spec['entry_refs'], entry, lang_id)
+                sfm2cldf.sfm_entry_to_cldf_row('EntryTable', spec['entry_map'], spec['entry_sources'], entry, lang_id)
                 for entry in entries]
             sense_rows = [
-                sfm2cldf.sfm_entry_to_cldf_row('SenseTable', spec['sense_map'], spec['sense_refs'], sense)
+                sfm2cldf.sfm_entry_to_cldf_row('SenseTable', spec['sense_map'], spec['sense_sources'], sense)
                 for sense in senses]
             example_rows = [
-                sfm2cldf.sfm_entry_to_cldf_row('ExampleTable', spec['example_map'], spec['example_refs'], example, lang_id)
+                sfm2cldf.sfm_entry_to_cldf_row('ExampleTable', spec['example_map'], spec['example_sources'], example, lang_id)
                 for example in examples]
             media_rows = [
                 {'ID': fileid, 'Language_ID': lang_id, 'Filename': filename}

--- a/src/pydictionaria/formats/sfm.py
+++ b/src/pydictionaria/formats/sfm.py
@@ -243,9 +243,12 @@ class Dictionary(base.Dictionary):
 
             id_index = sfm2cldf.make_id_index(entries)
 
-            crossref_processor = sfm2cldf.CrossRefs(
-                id_index,
-                sfm2cldf.LINKS_WITH_NO_LABEL | set(flexref_map.values()))
+            crossref_markers = (
+                sfm2cldf.DEFAULT_CROSS_REFERENCES
+                | set(props.get('cross_references', ()))
+                | set(flexref_map.values()))
+
+            crossref_processor = sfm2cldf.CrossRefs(id_index, crossref_markers)
             entries.visit(crossref_processor)
             senses.visit(crossref_processor)
             examples.visit(crossref_processor)

--- a/src/pydictionaria/formats/sfm.py
+++ b/src/pydictionaria/formats/sfm.py
@@ -241,9 +241,22 @@ class Dictionary(base.Dictionary):
                 file_list = ', '.join(sorted(map(repr, media_extr.orphans)))
                 log.warning('unknown media files: %s', file_list)
 
+            id_index = sfm2cldf.make_id_index(entries)
+
+            crossref_processor = sfm2cldf.CrossRefs(
+                id_index,
+                sfm2cldf.LINKS_WITH_NO_LABEL | set(flexref_map.values()))
+            entries.visit(crossref_processor)
+            senses.visit(crossref_processor)
+            examples.visit(crossref_processor)
+
             try:
-                sfm2cldf.process_links(
-                    props, entries, senses, examples, set(flexref_map.values()))
+                link_processor = sfm2cldf.make_link_processor(
+                    props, id_index, entries)
+                if link_processor is not None:
+                    entries.visit(link_processor)
+                    senses.visit(link_processor)
+                    examples.visit(link_processor)
             except ValueError as e:
                 log.warning('could not process links: %s', str(e))
 

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -54,7 +54,7 @@ DEFAULT_SOURCES = {}
 
 DEFAULT_PROCESS_LINKS_IN_LABELS = ()
 DEFAULT_LINK_DISPLAY_LABEL = 'lx'
-LINKS_WITH_NO_LABEL = {'mn', 'cf', 'cont', 'sy', 'an'}
+DEFAULT_CROSS_REFERENCES = {'mn', 'cf', 'cont', 'sy', 'an'}
 
 DEFAULT_SEPARATOR = ' ; '
 SEPARATORS = {

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -50,7 +50,7 @@ DEFAULT_FLEXREF_MAP = {
     'syn': 'sy',
     'ant': 'an'}
 
-DEFAULT_REFERENCES = {}
+DEFAULT_SOURCES = {}
 
 DEFAULT_PROCESS_LINKS_IN_LABELS = ()
 DEFAULT_LINK_DISPLAY_LABEL = 'lx'
@@ -88,7 +88,7 @@ def _local_mapping(json_mapping, default_mapping, marker_set, ref_mapping):
 
 
 def make_spec(properties, marker_set):
-    ref_mapping = ChainMap(properties.get('references', {}), DEFAULT_REFERENCES)
+    ref_mapping = ChainMap(properties.get('sources', {}), DEFAULT_SOURCES)
 
     entry_map, entry_markers, entry_columns, entry_refs = _local_mapping(
         properties.get('entry_map', {}),

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -52,7 +52,7 @@ DEFAULT_FLEXREF_MAP = {
 
 DEFAULT_SOURCES = {}
 
-DEFAULT_PROCESS_LINKS_IN_LABELS = ()
+DEFAULT_PROCESS_LINKS_IN_MARKERS = set()
 DEFAULT_LINK_LABEL_MARKER = 'lx'
 DEFAULT_CROSS_REFERENCES = {'mn', 'cf', 'cont', 'sy', 'an'}
 
@@ -528,22 +528,21 @@ def make_label_index(link_display_label, entries):
 
 
 def make_link_processor(properties, id_index, entries):
-    process_links_in_labels = set(properties.get(
-        'process_links_in_labels',
-        DEFAULT_PROCESS_LINKS_IN_LABELS))
+    link_markers = (
+        set(properties.get('process_links_in_markers', ()))
+        | DEFAULT_PROCESS_LINKS_IN_MARKERS)
     label_marker = properties.get(
         'link_label_marker',
         DEFAULT_LINK_LABEL_MARKER)
     link_regex = properties.get('link_regex')
 
-    if not process_links_in_labels:
+    if not link_markers:
         return None
     if link_regex is None:
         raise ValueError('Missing property: link_regex')
 
     link_labels = make_label_index(label_marker, entries)
-    return LinkProcessor(
-        id_index, link_labels, process_links_in_labels, link_regex)
+    return LinkProcessor(id_index, link_labels, link_markers, link_regex)
 
 
 def _single_spaces(s):

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -53,7 +53,7 @@ DEFAULT_FLEXREF_MAP = {
 DEFAULT_SOURCES = {}
 
 DEFAULT_PROCESS_LINKS_IN_LABELS = ()
-DEFAULT_LINK_DISPLAY_LABEL = 'lx'
+DEFAULT_LINK_LABEL_MARKER = 'lx'
 DEFAULT_CROSS_REFERENCES = {'mn', 'cf', 'cont', 'sy', 'an'}
 
 DEFAULT_SEPARATOR = ' ; '
@@ -531,9 +531,9 @@ def make_link_processor(properties, id_index, entries):
     process_links_in_labels = set(properties.get(
         'process_links_in_labels',
         DEFAULT_PROCESS_LINKS_IN_LABELS))
-    link_display_label = properties.get(
-        'link_display_label',
-        DEFAULT_LINK_DISPLAY_LABEL)
+    label_marker = properties.get(
+        'link_label_marker',
+        DEFAULT_LINK_LABEL_MARKER)
     link_regex = properties.get('link_regex')
 
     if not process_links_in_labels:
@@ -541,7 +541,7 @@ def make_link_processor(properties, id_index, entries):
     if link_regex is None:
         raise ValueError('Missing property: link_regex')
 
-    link_labels = make_label_index(link_display_label, entries)
+    link_labels = make_label_index(label_marker, entries)
     return LinkProcessor(
         id_index, link_labels, process_links_in_labels, link_regex)
 

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -11,6 +11,7 @@ import pycldf
 import csvw
 
 from pydictionaria import flextext
+from pydictionaria.utils import split_ids
 
 DEFAULT_ENTRY_SEP = r'\lx '
 DEFAULT_ENTRY_ID = 'lx'
@@ -449,6 +450,33 @@ class MediaExtractor(object):
 
         # Note: no-op on the actual entry
         return entry
+
+
+def make_id_index(entries):
+    return {
+        entry.original_id: entry.id
+        for entry in entries}
+
+
+class CrossRefs:
+
+    def __init__(self, id_index, crossref_markers):
+        self._index = id_index
+        self.crossref_markers
+
+    def _process_tag(self, tag, value):
+        if tag not in self.markers:
+            return tag, value
+        refs = split_ids(value)
+        refs = [self._index.get(ref, ref) for ref in refs]
+        return tag, ' ; '.join(refs)
+
+    def __call__(self, entry):
+        # Preserve both the type and any potential attributes of the entry
+        new_entry = copy.copy(entry)
+        new_entry.clear()
+        new_entry.extend(self._process_tag(tag, value) for tag, value in entry)
+        return new_entry
 
 
 class LinkIndex(object):

--- a/src/pydictionaria/sfm2cldf.py
+++ b/src/pydictionaria/sfm2cldf.py
@@ -534,16 +534,16 @@ def make_link_processor(properties, id_index, entries):
     link_display_label = properties.get(
         'link_display_label',
         DEFAULT_LINK_DISPLAY_LABEL)
-    id_regex = properties.get('entry_label_as_regex_for_link')
+    link_regex = properties.get('link_regex')
 
     if not process_links_in_labels:
         return None
-    if id_regex is None:
-        raise ValueError('Missing property: entry_label_as_regex_for_link')
+    if link_regex is None:
+        raise ValueError('Missing property: link_regex')
 
     link_labels = make_label_index(link_display_label, entries)
     return LinkProcessor(
-        id_index, link_labels, process_links_in_labels, id_regex)
+        id_index, link_labels, process_links_in_labels, link_regex)
 
 
 def _single_spaces(s):

--- a/src/pydictionaria/util.py
+++ b/src/pydictionaria/util.py
@@ -17,12 +17,8 @@ PY3 = sys.version_info[0] == 3
 ID_SEP_PATTERN = re.compile(r',|;')
 
 
-def unique(iterable):
-    return sorted(set(i for i in iterable if i))
-
-
 def split_ids(s, sep=ID_SEP_PATTERN):
-    return unique(id_.strip() for id_ in sep.split(s) if id_.strip())
+    return sorted(set(id_.strip() for id_ in sep.split(s) if id_.strip()))
 
 
 class MediaCatalog(object):

--- a/src/pydictionaria/util.py
+++ b/src/pydictionaria/util.py
@@ -18,7 +18,7 @@ ID_SEP_PATTERN = re.compile(r',|;')
 
 
 def unique(iterable):
-    return list(sorted(set(i for i in iterable if i)))
+    return sorted(set(i for i in iterable if i))
 
 
 def split_ids(s, sep=ID_SEP_PATTERN):


### PR DESCRIPTION
Problem: Processing cross-references is cumbersome:

 * Processing cross-references required the `md.json` to specify a regex
 * The link processing code created a markdown-style link -- and then stripped the markdown afterwards
 * Cross-references were just hard-coded

Some changes to link processing to make things easier:

 * Moved cross-reference processing out of link processing
 * Create separate JSON property `cross_references` (`\cf`, `\mn`, etc. are pre-defined)
 * Renamed some of the properties to make their function more clear (hopefully)

Changes for the `md.json`:
 1. `references` → `sources`
 2. `links_with_no_label` →  `cross_references`
 3. `process_links_in_labels` → `process_links_in_markers`
 4. `link_display_label` → `link_label_marker´
 5. `entry_label_as_regex_for_link` → `link_regex`